### PR TITLE
Fix username handling

### DIFF
--- a/puppetforge-exporter.rb
+++ b/puppetforge-exporter.rb
@@ -16,8 +16,8 @@ options.gateway_host = ENV['PUPPETFORGE_EXPORTER_HOST'] || 'http://127.0.0.1'
 # username precedence - take the values from the env var, override them
 # with any raw command line args and then possibly with the cli switch
 # in OptionParser
-options.user_names = ENV['PUPPETFORGE_EXPORTER_USERS='] || []
-options.user_names = ARGV.sort.uniq
+options.user_names = ENV['PUPPETFORGE_EXPORTER_USERS'].split(',') || []
+options.user_names = ARGV.sort.uniq unless ARGV.empty?
 
 OptionParser.new do |opts|
   opts.banner = <<-ENDOFUSAGE


### PR DESCRIPTION
The PUPPETFORGE_EXPORTER_USERS wasn't being accessed correctly and
when it was it was being overwritten by an empty ARGV. This was discovered
when testing the `Dockerfile`